### PR TITLE
fix header.html: signout button connect signview

### DIFF
--- a/english_diary/english_diary/templates/partials/header.html
+++ b/english_diary/english_diary/templates/partials/header.html
@@ -18,7 +18,7 @@
                     <li>
                         {% if request.user.is_authenticated %}
                         <a href="#">Signed in as {{request.user.username}}</a>
-                        <a href="{% url "users:signout" %}">Sign Out</a>
+                        <a href="{% url "users:signin" %}">Sign Out</a>
                         {% else %}
                         <a href="{% url "users:signin" %}">Sign In</a>
                         {% endif %}


### PR DESCRIPTION
header의 'signout' 버튼을 누르면 'signin view'로 이동하도록 수정

하지만 [logout]메소드가 작동 안하고 있으므로 좀 더 살펴보는 중